### PR TITLE
Initialize admin dashboard skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,5 @@
+module.exports = {
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: '@storybook/react'
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,3 @@
+export const parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' }
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# React-Templet-Boilarplate-admin
+# React Admin Dashboard Boilerplate
+
+This project provides a minimal starting point for a Material UI based admin dashboard.
+
+## Available Scripts
+
+- `npm start` – start development server
+- `npm run build` – build for production
+- `npm test` – run tests
+- `npm run storybook` – start storybook
+
+## Theming
+
+Primary and secondary colours can be updated in `src/theme/theme.ts`. Users can toggle dark and light mode using the switch in the header.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "admin-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,scss}'",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.0",
+    "@mui/material": "^5.14.0",
+    "@mui/styles": "^5.14.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.3",
+    "@types/node": "^20.3.1",
+    "@types/react": "^18.2.8",
+    "@types/react-dom": "^18.2.4",
+    "axios": "^1.4.0",
+    "chart.js": "^4.4.0",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3",
+    "react-hot-toast": "^2.4.1",
+    "react-spinners": "^0.13.8",
+    "react-router-dom": "^6.14.1",
+    "typescript": "^5.1.6"
+  },
+  "devDependencies": {
+    "@storybook/react": "^7.2.1",
+    "eslint": "^8.45.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-react": "^7.32.2",
+    "prettier": "^2.8.8",
+    "react-scripts": "5.0.1"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import theme from './theme/theme';
+import Dashboard from './pages/Dashboard';
+import Profile from './pages/Profile';
+import Landing from './pages/Landing';
+import Header from './components/Header';
+
+const App = () => {
+  const [dark, setDark] = useState(false);
+  const toggleTheme = () => setDark(!dark);
+
+  return (
+    <ThemeProvider theme={dark ? theme.dark : theme.light}>
+      <CssBaseline />
+      <Router>
+        <Header toggleTheme={toggleTheme} dark={dark} />
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/profile" element={<Profile />} />
+        </Routes>
+      </Router>
+    </ThemeProvider>
+  );
+};
+
+export default App;

--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api'
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => Promise.reject(error)
+);
+
+export default api;

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import Header from './Header';
+
+export default {
+  title: 'Components/Header',
+  component: Header
+};
+
+const Template: StoryFn<{ dark: boolean }> = (args) => (
+  <Header {...args} toggleTheme={() => {}} />
+);
+
+export const Light = Template.bind({});
+Light.args = {
+  dark: false
+};
+
+export const Dark = Template.bind({});
+Dark.args = {
+  dark: true
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, Switch } from '@mui/material';
+
+interface HeaderProps {
+  toggleTheme: () => void;
+  dark: boolean;
+}
+
+const Header = ({ toggleTheme, dark }: HeaderProps) => (
+  <AppBar position="static">
+    <Toolbar>
+      <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+        Admin Dashboard
+      </Typography>
+      <Switch checked={dark} onChange={toggleTheme} />
+    </Toolbar>
+  </AppBar>
+);
+
+export default Header;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import theme from './theme/theme';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme.light}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const Dashboard = () => (
+  <Box p={2}>
+    <Typography variant="h4">Dashboard</Typography>
+  </Box>
+);
+
+export default Dashboard;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const Landing = () => (
+  <Box p={2}>
+    <Typography variant="h4">Landing Page</Typography>
+  </Box>
+);
+
+export default Landing;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const Profile = () => (
+  <Box p={2}>
+    <Typography variant="h4">Profile</Typography>
+  </Box>
+);
+
+export default Profile;

--- a/src/styles/example.module.scss
+++ b/src/styles/example.module.scss
@@ -1,0 +1,3 @@
+.box {
+  padding: 1rem;
+}

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+
+test('renders landing page', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/Landing Page/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,19 @@
+import { createTheme } from '@mui/material/styles';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#1976d2' },
+    secondary: { main: '#9c27b0' }
+  }
+});
+
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: { main: '#90caf9' },
+    secondary: { main: '#ce93d8' }
+  }
+});
+
+export default { light: lightTheme, dark: darkTheme };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add minimal package setup with React, MUI, and tooling
- configure eslint, prettier and tsconfig
- scaffold basic theming and routing
- add sample components, pages, API util, and styles
- provide Storybook and test example

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686750733f448328a7064fe10b9bd2db